### PR TITLE
Pull in new Fill-In Regional Ordering Script

### DIFF
--- a/Automated Process/SQL/regional_ordering_w_filin.sql
+++ b/Automated Process/SQL/regional_ordering_w_filin.sql
@@ -48,7 +48,7 @@ create local temp table inv_base on commit preserve rows as
                 and l.location_active_warehouse = 1
                 and l.location_warehouse_type = 0
                 and l.product_company_description = 'Chewy'
-                and i.product_part_number='109408'
+--                and i.product_part_number='109408'
 ;
 
 drop table if exists products;
@@ -101,7 +101,7 @@ create local temp table reg_fcast on commit preserve rows as
                         and l.location_active_warehouse = 1
                         and l.location_warehouse_type = 0
                         and l.product_company_description = 'Chewy'
-                        and product_part_number='109408'
+--                        and product_part_number='109408'
                         group by 1,2,3
                 )
         select *
@@ -135,7 +135,7 @@ create local temp table reg_oo_weekly on commit preserve rows as
         where 1=1
                 and (lotID like '%%RS%%' or lotID like '%%TR%%')
                 and date(year||'-'||month||'-'||day) >= current_date
-                and c.item='109408'
+--                and c.item='109408'
         group by 1,2,3
 ;
 
@@ -287,7 +287,7 @@ create local temp table props on commit preserve rows as
         where 1=1
                 and (prop.supplier is null or prop.supplier not in (select distinct location_code from reg)) --We do not want to order self-transfers
                 and coalesce(p.product_discontinued_flag,false) is false
-                and cil.item='109408'
+--                and cil.item='109408'
         order by 1,2
 ;
 --select * from props;

--- a/Automated Process/SQL/regional_ordering_w_filin.sql
+++ b/Automated Process/SQL/regional_ordering_w_filin.sql
@@ -111,14 +111,14 @@ create local temp table reg_fcast on commit preserve rows as
         from base
 ;
 
-drop table if exists network_fcast;
-create local temp table network_fcast on commit preserve rows as
-        select product_part_number
-                , week
-                , SUM(forecast_region) as forecast_network
-        from reg_fcast
-        group by 1,2
-;
+--drop table if exists network_fcast;
+--create local temp table network_fcast on commit preserve rows as
+--        select product_part_number
+--                , week
+--                , SUM(forecast_region) as forecast_network
+--        from reg_fcast
+--        group by 1,2
+--;
 
 drop table if exists reg_oo_weekly;
 create local temp table reg_oo_weekly on commit preserve rows as
@@ -180,9 +180,9 @@ create local temp table reg_base on commit preserve rows as
                 ,f.cumulative_forecast_region
                 ,f.avg_daily_forecast_week
                 ,f.week_rank_region
-                ,nf.forecast_network
+--                ,nf.forecast_network
                 ,oo.oo_region as oo_region_for_week
-                ,noo.oo_network as oo_network_for_week
+--                ,noo.oo_network as oo_network_for_week
         from reg_inv r
         join network_inv n using(product_part_number)
         join sandbox_supply_chain.outl_excess_base o 
@@ -194,10 +194,10 @@ create local temp table reg_base on commit preserve rows as
         left join reg_oo_weekly oo on r.product_part_number=oo.product_part_number
                         and r.region=oo.region
                         and f.week=oo.week
-        left join network_fcast nf on r.product_part_number=nf.product_part_number
-                                        and f.week=nf.week
-        left join network_oo_weekly noo on r.product_part_number=noo.product_part_number
-                                and f.week=noo.week
+--        left join network_fcast nf on r.product_part_number=nf.product_part_number
+--                                        and f.week=nf.week
+--        left join network_oo_weekly noo on r.product_part_number=noo.product_part_number
+--                                and f.week=noo.week
 ;
 
 --Get future states at regional level
@@ -213,20 +213,20 @@ create local temp table reg_fin on commit preserve rows as
 ; 
 
 --Get future inventory states at network level
-drop table if exists network_fin;
-create local temp table network_fin on commit preserve rows as
-       select sandbox_supply_chain.inventory_projection(product_part_number::varchar,
-                week::date,
-                current_on_hand_network::int,
-                forecast_network::float,
-                oo_network_for_week::int) over(partition by product_part_number)
-        from (select distinct product_part_number
-                        , week
-                        , current_on_hand_network
-                        , forecast_network
-                        , oo_network_for_week
-                from reg_base) r
-;
+--drop table if exists network_fin;
+--create local temp table network_fin on commit preserve rows as
+--       select sandbox_supply_chain.inventory_projection(product_part_number::varchar,
+--                week::date,
+--                current_on_hand_network::int,
+--                forecast_network::float,
+--                oo_network_for_week::int) over(partition by product_part_number)
+--        from (select distinct product_part_number
+--                        , week
+--                        , current_on_hand_network
+--                        , forecast_network
+--                        , oo_network_for_week
+--                from reg_base) r
+--;
 
 drop table if exists final;
 create local temp table final on commit preserve rows as
@@ -240,53 +240,21 @@ create local temp table final on commit preserve rows as
                 ,f.oo as projected_on_order_region
                 ,f.inv as projected_on_hand_region
                 ,f.forecast as region_forecast
-                ,nf.oo as projected_on_order_network
-                ,nf.inv as projected_on_hand_network
-                ,nf.forecast as network_forecast
+--                ,nf.oo as projected_on_order_network
+--                ,nf.inv as projected_on_hand_network
+--                ,nf.forecast as network_forecast
                 ,zeroifnull(r.avg_daily_forecast) as avg_daily_forecast
                 ,r.forecast_region
                 ,zeroifnull(r.avg_daily_forecast_week) as avg_daily_forecast_week
         from reg_fin f
         join products p using(product_part_number)
-        join network_fin nf on f.product_part_number=nf.product_part_number
-                        and f.week=nf.week
+--        join network_fin nf on f.product_part_number=nf.product_part_number
+--                        and f.week=nf.week
         join reg_base r on f.region=r.region
                         and f.product_part_number=r.product_part_number
                         and f.week=r.week
 ;
 
---Get full item-FC set to get all OUTLs as proposals don't account for all item-FCs
---Only look at assorted items as non-assorted items do not get replenished; therefore no OUTL
---drop table if exists props;
---create local temp table props on commit preserve rows as
---        select cil.item
---                ,cil.location as location
---                ,qty as proposed_qty
---                ,tpeh.supplier
---                ,v.vendor_name
---                ,cil.MINRESINT as review_period
---                ,cil.MINRESLOT as MOQ
---                ,prundate::date
---                ,duedate::date
---                ,(min(duedate) over (partition by cil.item, region))::date as min_ERDD_region
---                ,reg.region
---                ,status
---        from chewy_prod_740.C_ITEMLOCATION cil
---        join reg on reg.location_code=cil.location
---        join chewybi.products p on p.product_part_number=cil.item
---        left join chewy_prod_740.t_proposals_edit tpeh
---                on tpeh.item=cil.item
---                and left(tpeh.destwhs,4)=cil.location
---                and tpeh.supplier=cil.supplier
---                and tpeh.prundate = current_date
-----                and status != 'X'
---        left join chewybi.vendors v on split_part(tpeh.supplier,'-',1)=v.vendor_number
---        where 1=1
---                and (tpeh.supplier is null or tpeh.supplier not in (select distinct location_code from reg)) --We do not want to order self-transfers
---                and coalesce(p.product_discontinued_flag,false) is false
---        order by 1,2
---;
---to test while in-between order days
 drop table if exists props;
 create local temp table props on commit preserve rows as
         select cil.item
@@ -312,8 +280,8 @@ create local temp table props on commit preserve rows as
         left join chewybi.T_PROPOSALS_EDIT_SNAPSHOT prop 
                 on cil.item=prop.item
                 and cil.location=left(prop.destwhs,4)
-                and prop.prundate=current_date-1
-                and prop.create_date=current_date-1
+                and prop.prundate=current_date
+                and prop.create_date=current_date
         left join chewybi.vendors v on split_part(prop.supplier,'-',1)=v.vendor_number
         where 1=1
                 and (prop.supplier is null or prop.supplier not in (select distinct location_code from reg)) --We do not want to order self-transfers
@@ -370,16 +338,16 @@ create local temp table reg_tunnel on commit preserve rows as
 
 
 --Get network level metrics for each item
-drop table if exists network_tunnel;
-create local temp table network_tunnel on commit preserve rows as
-        select item
---                ,is_fillin
-                ,sum(greatest(0,total_reg_OUTL_so99)) as total_network_OUTL_so99
-                ,sum(greatest(0,total_reg_IP_so99)) as total_network_IP_so99
-                ,sum(greatest(0,total_reg_OUTL_so99))-sum(greatest(0,total_reg_IP_so99)) as total_network_NEED_so99
-        from reg_tunnel
-        group by 1--,2
-;
+--drop table if exists network_tunnel;
+--create local temp table network_tunnel on commit preserve rows as
+--        select item
+----                ,is_fillin
+--                ,sum(greatest(0,total_reg_OUTL_so99)) as total_network_OUTL_so99
+--                ,sum(greatest(0,total_reg_IP_so99)) as total_network_IP_so99
+--                ,sum(greatest(0,total_reg_OUTL_so99))-sum(greatest(0,total_reg_IP_so99)) as total_network_NEED_so99
+--        from reg_tunnel
+--        group by 1--,2
+--;
 --select * from network_tunnel;
 
 drop table if exists full_tunnel;
@@ -397,21 +365,21 @@ create local temp table full_tunnel on commit preserve rows as
                 ,t.review_period
                 ,t.prundate as release_date
                 ,t.duedate as ERDD --fill in for item-FCs without a proposal
-                ,fin.projected_on_hand_region
                 ,case when zeroifnull(fin.projected_on_hand_region) <= 0 then true else false end as projected_region_oos_ERDDweek
-                ,case when zeroifnull(fin.projected_on_hand_network) <= 0 then true else false end as projected_network_oos_ERDDweek
+                ,fin.projected_on_hand_region
+--                ,case when zeroifnull(fin.projected_on_hand_network) <= 0 then true else false end as projected_network_oos_ERDDweek
                 ,fin.projected_on_order_region
-                ,fin.projected_on_hand_network
-                ,fin.projected_on_order_network
+--                ,fin.projected_on_hand_network
+--                ,fin.projected_on_order_network
                 ,t.FC_OUTL_so99
                 ,t.FC_IP_so99
                 ,t.FC_NEED_so99
                 ,rt.total_reg_OUTL_so99
                 ,rt.total_reg_IP_so99
                 ,rt.total_reg_NEED_so99
-                ,nt.total_network_OUTL_so99
-                ,nt.total_network_IP_so99
-                ,nt.total_network_NEED_so99
+--                ,nt.total_network_OUTL_so99
+--                ,nt.total_network_IP_so99
+--                ,nt.total_network_NEED_so99
                 
                 ,fin.current_on_hand_network
                 ,fin.current_on_order_network
@@ -421,25 +389,26 @@ create local temp table full_tunnel on commit preserve rows as
                 ,outl.outl-outl.oh_oo as current_NEED_network
                 
                 ,t.proposed_qty as proposed_FC_qty
+
                 ,outl.oh_oo+sum(t.proposed_qty) over (partition by t.item order by fc_need_rank_in_network asc) as current_network_IP_with_proposed_qty_cummulative_calcd --What will IP be if we place order?
                 ,(outl.oh_oo+sum(t.proposed_qty) over (partition by t.item order by fc_need_rank_in_network asc)) - outl.outl as current_network_excess_created_cummulative_calcd --Positive value when Excess inventory created. Calculate the running SUM of Delta(IP-OUTL) to see when it begins to become excess at the network level
                 
-                ,total_network_IP_so99+sum(t.proposed_qty) over (partition by t.item order by fc_need_rank_in_network asc) as current_network_IP_with_proposed_qty_cummulative_so99
-                ,(total_network_IP_so99+sum(t.proposed_qty) over (partition by t.item order by fc_need_rank_in_network asc)) - total_network_OUTL_so99 as current_network_excess_created_cummulative_so99
+--                ,total_network_IP_so99+sum(t.proposed_qty) over (partition by t.item order by fc_need_rank_in_network asc) as current_network_IP_with_proposed_qty_cummulative_so99
+--                ,(total_network_IP_so99+sum(t.proposed_qty) over (partition by t.item order by fc_need_rank_in_network asc)) - total_network_OUTL_so99 as current_network_excess_created_cummulative_so99
                 
                 ,t.fc_need_rank_in_region --based on SO99 
-                ,t.fc_need_rank_in_network --based on SO99
+--                ,t.fc_need_rank_in_network --based on SO99
                 
                 ,sum(t.proposed_qty) over (partition by t.item,t.region order by fc_need_rank_in_region asc) as region_proposed_QTY_cummulative
                 ,total_reg_NEED_so99 - sum(t.proposed_qty) over (partition by t.item,t.region order by fc_need_rank_in_region asc) as region_need_left_after_order_cummulative_so99 --excess inventory when value is negative
-                ,sum(t.proposed_qty) over (partition by t.item order by fc_need_rank_in_network asc) as network_proposed_QTY_cummulative
-                ,total_network_NEED_so99 - sum(t.proposed_qty) over (partition by t.item order by fc_need_rank_in_network asc) as network_need_left_after_order_cummulative_so99 --excess inventory when value is negative
+--                ,sum(t.proposed_qty) over (partition by t.item order by fc_need_rank_in_network asc) as network_proposed_QTY_cummulative
+--                ,total_network_NEED_so99 - sum(t.proposed_qty) over (partition by t.item order by fc_need_rank_in_network asc) as network_need_left_after_order_cummulative_so99 --excess inventory when value is negative
 --                ,sum(t.FC_NEED) over (partition by t.item order by fc_need_rank_in_network asc) as network_NEED_cummulative
         from tunnel t
         join reg_tunnel rt on t.item=rt.item
                         and t.region=rt.region
 --                        and t.is_fillin=rt.is_fillin
-        join network_tunnel nt on t.item=nt.item
+--        join network_tunnel nt on t.item=nt.item
 --                                and t.is_fillin=nt.is_fillin
         left join sandbox_supply_chain.outl_excess_base outl on t.item=outl.product_part_number
                                                                 and outl.snapshot_date=current_date
@@ -450,8 +419,6 @@ create local temp table full_tunnel on commit preserve rows as
         order by item,region,fc_need_rank_in_region
 ;
 --select * from full_tunnel;
---QQ: Do we want to base regional OOS on Direct or Distro ERDD week? 
-        --ALso, we are currently calculating regional Need using Distro SS and IP. We should rather use Primary regional OUTL,IP,Need for all Distro props too
 
 drop table if exists need_calcs;
 create local temp table need_calcs on commit preserve rows as
@@ -461,13 +428,13 @@ create local temp table need_calcs on commit preserve rows as
                         when proposed_FC_qty >= -1*region_need_left_after_order_cummulative_so99 then (proposed_FC_qty+region_need_left_after_order_cummulative_so99) / proposed_FC_qty 
                         else 0
                         end as FC_Region_need_Percent_so99
-                ,case when network_need_left_after_order_cummulative_so99 >= 0 then 1 --If there is still network NEED then the proposal order is 100% needed
-                        when proposed_FC_qty >= -1*network_need_left_after_order_cummulative_so99 then (proposed_FC_qty+network_need_left_after_order_cummulative_so99) / proposed_FC_qty
-                        else 0
-                        end as FC_Network_need_percent_cummulative_so99
-                ,case when network_need_left_after_order_cummulative_so99 >= 0 then 0 --when there is still network NEED then there is 0 units excess DOS
-                        else (-1*(total_network_NEED_so99 - network_need_left_after_order_cummulative_so99)) / nullifzero(avg_daily_forecast) --Take delta of current Network Need - network_need after order is placed to get how much un-needed units were purchased
-                        end as network_excess_created_from_order_cummulative_DOS_so99
+--                ,case when network_need_left_after_order_cummulative_so99 >= 0 then 1 --If there is still network NEED then the proposal order is 100% needed
+--                        when proposed_FC_qty >= -1*network_need_left_after_order_cummulative_so99 then (proposed_FC_qty+network_need_left_after_order_cummulative_so99) / proposed_FC_qty
+--                        else 0
+--                        end as FC_Network_need_percent_cummulative_so99
+--                ,case when network_need_left_after_order_cummulative_so99 >= 0 then 0 --when there is still network NEED then there is 0 units excess DOS
+--                        else (-1*(total_network_NEED_so99 - network_need_left_after_order_cummulative_so99)) / nullifzero(avg_daily_forecast) --Take delta of current Network Need - network_need after order is placed to get how much un-needed units were purchased
+--                        end as network_excess_created_from_order_cummulative_DOS_so99
                 ,network_proposed_QTY_cummulative / nullifzero(avg_daily_forecast) as proposed_ordered_units_cummulative_DOS_so99
         from full_tunnel ft
 --        where item='266944'

--- a/KPI Metric Tracking/Regional In-stock Tracking.sql
+++ b/KPI Metric Tracking/Regional In-stock Tracking.sql
@@ -1,0 +1,80 @@
+drop table if exists regional_orders;
+create local temp table regional_orders
+        (action varchar(10)
+        ,item_id varchar(6)
+        ,region varchar(12)
+        ,location_cd varchar(4)
+        ,supplier varchar(15)
+        ,proposed_qty int
+        ,fc_region_need_percent float)
+on commit preserve rows;
+copy regional_orders
+from local 'C:\Users\cmorris10\Downloads\6-13-22_orders.csv'
+parser fcsvparser(delimiter = ',');
+
+drop table if exists reg;
+create local temp table reg on commit preserve rows as
+        select 'AVP1' as location_code, 'East' as region union all
+        select 'AVP2' as location_code, 'East' as region union all
+        select 'CFC1' as location_code, 'Central' as region union all
+        select 'CLT1' as location_code, 'South East' as region union all
+        select 'DAY1' as location_code, 'Central' as region union all
+        select 'DFW1' as location_code, 'Central' as region union all
+        select 'EFC3' as location_code, 'East' as region union all
+        select 'MCI1' as location_code, 'Central' as region union all
+        select 'MCO1' as location_code, 'South East' as region union all
+        select 'MDT1' as location_code, 'East' as region union all
+        select 'PHX1' as location_code, 'West' as region union all
+        select 'RNO1' as location_code, 'West' as region union all
+        select 'WFC2' as location_code, 'West' as region
+;
+
+drop table if exists item_fc_data;
+create local temp table item_fc_data on commit preserve rows as
+        select inventory_snapshot_snapshot_dt as snapshot_date
+                ,ro.item_id
+                ,i.location_code
+                ,region
+                ,coalesce(i.inventory_snapshot_sellable_quantity,0) as sellable_units
+                ,coalesce(p.product_discontinued_flag,false) as product_discontinued_flag
+        from (select distinct item_id
+                from regional_orders) ro
+        join chewybi.inventory_snapshot i
+                on ro.item_id=i.product_part_number
+        join reg using(location_code)
+        join chewybi.product_lifecycle_snapshot p
+                on i.inventory_snapshot_snapshot_dt=p.snapshot_date
+                and i.product_part_number=p.product_part_number
+        where 1=1
+                and i.inventory_snapshot_snapshot_dt between '2022-04-01' and current_date-1
+        order by 1,2
+;
+
+drop table if exists item_reg_data;
+create local temp table item_reg_data on commit preserve rows as
+        select snapshot_date
+                ,item_id
+                ,region
+                ,case when SUM(sellable_units) > 0 then 0 else 1 end as region_OOS
+        from item_fc_data
+        where 1=1
+                and product_discontinued_flag is false --Only accounting for replenishable items as OOS for a Disco item is expected
+        group by 1,2,3
+        order by 1,2
+;
+
+select * from item_reg_data limit 1000;
+
+select snapshot_date
+        ,region
+        ,COUNT(*) as number_of_items --HG+Specialty
+        ,SUM(region_OOS) as items_OOS_in_region
+        ,round(SUM(region_OOS) / COUNT(*),4) as region_OOS_percentage
+from item_reg_data
+group by 1,2
+order by 2,1;
+
+
+--TODO: HG vs Non-HG OOS rates
+
+

--- a/KPI Metric Tracking/Shipping Zone Tracking.sql
+++ b/KPI Metric Tracking/Shipping Zone Tracking.sql
@@ -1,37 +1,50 @@
 -----------------------------------
 -- Average Zone Shipped Tracking --
 -----------------------------------
-select product_part_number
-        ,sol.order_line_id
-        ,l.location_code
-        ,common_date_dttm::date as order_date
-        ,shipment_quantity
-        ,actual_zone
---        ,median(actual_zone) over (partition by location_code,common_date_dttm::date) as med_FC_zone_shipped
-from chewybi.shipment_order_line sol
-join chewybi.order_line_cost_measures olcm
-        on sol.order_line_id=olcm.order_line_id
-join chewybi.products p using(product_key)
-join chewybi.locations l on l.location_key=olcm.fulfillment_center_key
-join chewybi.common_date cd on cd.common_date_key=olcm.order_placed_date_key
-where 1=1
-        and p.product_part_number='141529'
-        and common_date_dttm::date between current_date -90 and current_date-1
+drop table if exists regional_orders;
+create local temp table regional_orders
+        (action varchar(10)
+        ,item_id varchar(6)
+        ,region varchar(12)
+        ,location_cd varchar(4)
+        ,supplier varchar(15)
+        ,proposed_qty int
+        ,fc_region_need_percent float)
+on commit preserve rows;
+copy regional_orders
+from local 'C:\Users\cmorris10\Downloads\6-8-22_orders.csv'
+parser fcsvparser(delimiter = ',');
+
+drop table if exists order_history;
+create local temp table order_history on commit preserve rows as
+        select product_part_number
+                ,sol.order_line_id
+                ,l.location_code
+                ,common_date_dttm::date as order_date
+                ,shipment_quantity
+                ,actual_zone
+        --        ,median(actual_zone) over (partition by location_code,common_date_dttm::date) as med_FC_zone_shipped
+        from chewybi.shipment_order_line sol
+        join chewybi.order_line_cost_measures olcm
+                on sol.order_line_id=olcm.order_line_id
+        join chewybi.products p using(product_key)
+        join chewybi.locations l on l.location_key=olcm.fulfillment_center_key
+        join chewybi.common_date cd on cd.common_date_key=olcm.order_placed_date_key
+        join (select distinct item_id from regional_orders) ro on p.product_part_number=ro.item_id
+        where 1=1
+        --        and p.product_part_number='141529'
+                and l.fulfillment_active is true
+                and l.location_active_warehouse = 1
+                and l.location_warehouse_type = 0
+                and l.product_company_description = 'Chewy'
+                and common_date_dttm::date between current_date -90 and current_date-1
 ;
 
-select --product_part_number
-        l.location_code
-        ,common_date_dttm::date as order_date
+select product_part_number
+--        location_code
+        ,date_trunc('week',order_date) as order_week
         ,round(avg(actual_zone),0) as avg_zone_shipped
-from chewybi.shipment_order_line sol
-join chewybi.order_line_cost_measures olcm
-        on sol.order_line_id=olcm.order_line_id
-join chewybi.products p using(product_key)
-join chewybi.locations l on l.location_key=olcm.fulfillment_center_key
-join chewybi.common_date cd on cd.common_date_key=olcm.order_placed_date_key
-where 1=1
-        and p.product_part_number='141529'
-        and common_date_dttm::date between current_date -90 and current_date-1
+from order_history
 group by 1,2--,3
 order by 1,2--,3
 ;

--- a/KPI Metric Tracking/Shipping Zone Tracking.sql
+++ b/KPI Metric Tracking/Shipping Zone Tracking.sql
@@ -1,6 +1,7 @@
 -----------------------------------
 -- Average Zone Shipped Tracking --
 -----------------------------------
+-- 7 NB HG/Specialty Planner Codes: ('PPRAKASH','BROSEN','MODZER','BNEUBAUER','MWILSON','SSHARAN','JMALAVIYA')
 drop table if exists regional_orders;
 create local temp table regional_orders
         (action varchar(10)
@@ -12,43 +13,124 @@ create local temp table regional_orders
         ,fc_region_need_percent float)
 on commit preserve rows;
 copy regional_orders
-from local 'C:\Users\cmorris10\Downloads\6-8-22_orders.csv'
+from local 'C:\Users\cmorris10\Downloads\6-13-22_orders.csv'
 parser fcsvparser(delimiter = ',');
 
-drop table if exists order_history;
-create local temp table order_history on commit preserve rows as
-        select product_part_number
-                ,sol.order_line_id
-                ,l.location_code
-                ,common_date_dttm::date as order_date
-                ,shipment_quantity
-                ,actual_zone
-        --        ,median(actual_zone) over (partition by location_code,common_date_dttm::date) as med_FC_zone_shipped
-        from chewybi.shipment_order_line sol
-        join chewybi.order_line_cost_measures olcm
-                on sol.order_line_id=olcm.order_line_id
-        join chewybi.products p using(product_key)
-        join chewybi.locations l on l.location_key=olcm.fulfillment_center_key
-        join chewybi.common_date cd on cd.common_date_key=olcm.order_placed_date_key
-        join (select distinct item_id from regional_orders) ro on p.product_part_number=ro.item_id
+drop table if exists locations;
+create local temp table locations on commit preserve rows as
+        select location_key
+                ,location_code
+        from chewybi.locations l
         where 1=1
-        --        and p.product_part_number='141529'
                 and l.fulfillment_active is true
                 and l.location_active_warehouse = 1
                 and l.location_warehouse_type = 0
                 and l.product_company_description = 'Chewy'
-                and common_date_dttm::date between current_date -90 and current_date-1
 ;
 
-select product_part_number
---        location_code
-        ,date_trunc('week',order_date) as order_week
-        ,round(avg(actual_zone),0) as avg_zone_shipped
-from order_history
-group by 1,2--,3
-order by 1,2--,3
+-------------------------------------------------------------------------------------
+-- Measure average zone impact for orders w/NB HG items vs. orders w/o NB HG items --
+-------------------------------------------------------------------------------------
+drop table if exists nb_hg_items;
+create local temp table nb_hg_items on commit preserve rows as
+        select distinct item_id
+        from regional_orders
+        order by 1
+;
+
+drop table if exists item_ship_zones;
+create local temp table item_ship_zones on commit preserve rows as
+        select olm.order_key
+--                ,case when count(distinct location_code) > 1 then 1 else 0 end as is_split
+                ,least(1,sum(case when nb.item_id is not null then 1 else 0 end)) as contains_nbhg_item 
+                ,min(order_line_released_dttm::date) as order_released_date
+                ,avg(actual_zone) as actual_zone
+        from chewybi.order_line_measures olm 
+        join chewybi.orders o using(order_key)
+        join chewybi.shipment_order_line sol on olm.order_line_id=sol.order_line_id
+        join locations l on location_key = fulfillment_center_key
+        join chewybi.products p on olm.product_key=p.product_key
+        left join nb_hg_items nb on p.product_part_number=nb.item_id
+        where order_status not in ('X','J')
+        group by 1
+        having min(order_line_released_dttm::date) between '2022-04-01' and current_date - 1
+        order by 1
+;
+
+select order_released_date
+        ,contains_nbhg_item
+        ,avg(actual_zone) as avg_zone_shipped
+from item_ship_zones z
+group by 1,2
+order by 1,2
 ;
 
 select * from chewybi.order_line_cost_measures where order_line_id='1384020626';
 select * from chewybi.customers where customer_key='32565750453';
 select * from chewybi.customer_addresses where customer_address_id='59449682';
+
+----------------------------------------------------------------------------------
+-- Measure Split% impact for orders w/NB HG items vs. orders w/o NB HG items --
+----------------------------------------------------------------------------------
+drop table if exists splits;
+create local temp table splits on commit preserve rows as
+        select olm.order_key
+                ,min(order_line_released_dttm::date) as order_released_date
+                ,case when count(distinct location_code) > 1 then 1 else 0 end as is_split
+        from chewybi.order_line_measures olm 
+        join chewybi.orders o using(order_key)
+        join locations l on location_key = fulfillment_center_key
+        join chewybi.products p on olm.product_key=p.product_key
+        where order_status not in ('X','J')
+        group by 1
+        having min(order_line_released_dttm::date) between current_date - 90 and current_date - 1
+;
+
+drop table if exists split_prods;
+create local temp table split_prods on commit preserve rows as
+        select s.*
+                ,product_part_number
+        from splits s
+        join chewybi.order_line_measures olm using(order_key)
+        join chewybi.products p using(product_key)
+;
+
+drop table if exists nb_hg_items;
+create local temp table nb_hg_items on commit preserve rows as
+        select distinct item_id
+        from regional_orders
+        order by 1
+;
+
+with a as (
+        select order_released_date
+                ,order_key
+                ,max(is_split) as is_split
+                ,least(1,sum(case when item_id is not null then 1 else 0 end)) as contains_nbhg_item 
+        from split_prods
+        left join nb_hg_items nb on nb.item_id = product_part_number
+        group by 1,2
+)
+select order_released_date
+        ,contains_nbhg_item
+        ,sum(is_split) / count(*) as split_rate
+        ,sum(is_split) as split_order_count
+        ,count(*) as count_orders 
+from a 
+group by 1,2
+order by 1,2;
+--)
+---- To get top Brands contributing to Splits
+--select s.product_part_number
+----         p.product_purchase_brand
+--        , p.cartonization_flag
+--        , count(distinct order_key) as split_order_count
+--from split_prods s
+--left join ag on ag.item=s.product_part_number
+--join chewybi.products p using(product_part_number)
+--where case when ag.item is not null then true else false end is true
+--        and is_split=1
+--group by 1,2
+--order by 2 desc
+--;
+


### PR DESCRIPTION
This PR pulls in the updated script that moves from using Dhiral's current ordering logic to using the regional ordering logic.

**Key Feature:**
1. All Fill-in proposals are rejected unless the Region is projected to be OOS. Uses the LT of the Distro vendor to get the projected OH units.